### PR TITLE
Bump Triton docker to moyix/triton_with_ft:22.09

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   triton:
-    image: moyix/triton_with_ft:22.06
+    image: moyix/triton_with_ft:22.09
     command: bash -c "CUDA_VISIBLE_DEVICES=${GPUS} mpirun -n 1 --allow-run-as-root /opt/tritonserver/bin/tritonserver --model-repository=/model"
     shm_size: '2gb'
     volumes:


### PR DESCRIPTION
This version of the Docker image supports a wider range of cards (down to SM 6.0), so it should be compatible with older cards. The corresponding commit to build the image is https://github.com/moyix/fastertransformer_backend/commit/a34df0f053d429e6a6f5b2aec8a8a95e5e25fd3d . Fixes #30 .